### PR TITLE
Adds environmenr variables use, fixes bugs, handles processing errors, makes each experiment now log each class instances with cometml

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,21 @@ conda env create --name envname --file=environment.yml
 pip install -r requirements.txt
 ```
 
-3. Configurar credenciales (❗WORK IN PROGRESS❗):
-- Modificar `credentials.json` para cada usuario personalmente
-- Añadir tu API key de HuggingFace en el archivo
-- Añadir tu API key de CometML en el archivo
-
+3. Necesitas añadir las variables de entorno para tu entorno conda para el correcto funcionamiento.
+* Añadir las variables nuevas❗
+  ```bash
+  conda env config vars set COMET_API_KEY="introduce tu clave"
+  conda env config vars set HF_API_KEY="introduce tu clave"
+  ```
+* Puedes ver las variables definidas de entorno:
+  ```bash
+  conda env config vars list -n myenv
+  ```
+* O también quitar algunas:
+  ```bash
+  conda env config vars unset COMET_API_KEY -n nombre_de_entorno
+  ```
+  
 ## 💻 Uso
 
 ### Carga del dataset
@@ -45,7 +55,7 @@ python load_and_process.py
 
 ### Entrenamiento Básico
 ```bash
-python yolo_trainer.py --config yolo_config.yaml --comet-key your_api_key --comet-project your_cometml_project_name
+python yolo_trainer.py --config yolo_config.yaml
 ```
 
 ## 🛠️ Funcionalidades Principales

--- a/config/yolo_config.yaml
+++ b/config/yolo_config.yaml
@@ -4,6 +4,8 @@ task: "detect"
 
 # Datos
 data: "/home/jovyan/work/isr-innovation/isr-oit-acerinox-cs6-images/data/data.yaml"
+#Directorio de dataset en general
+dataset_dir: "/home/jovyan/work/isr-innovation/isr-oit-acerinox-cs6-images/data" 
 project: "jupyterhub_demo"
 
 # Parámetros de entrenamiento

--- a/scripts/load_and_process.py
+++ b/scripts/load_and_process.py
@@ -44,9 +44,9 @@ class DatasetProcessor:
         print("\n=== Descargador y Procesador de Datasets de Hugging Face ===\n")
 
         # Get API key
-        api_key = input("Ingresa tu Hugging Face API key (consulta https://huggingface.co/settings/tokens): ").strip()
+        api_key = os.environ.get("HF_API_KEY")
         if not api_key:
-            print("Error: Se requiere una API key válida.")
+            print("Error: Se requiere una API key válida. El API key se coge de las variables de entorno de Conda. puedes consultar las variables de entorno actuales con conda env config vars list -n myenv")
             return False
 
         # Login to Hugging Face

--- a/scripts/yolo_trainer.py
+++ b/scripts/yolo_trainer.py
@@ -18,7 +18,7 @@ class YOLOTrainer:
         """
         self.config = config
         self.model = None
-        self.comet_api_key = None
+        self.comet_api_key = os.environ.get("COMET_API_KEY")
         self.comet_project = None
         
     def setup_comet(self) -> bool:

--- a/scripts/yolo_trainer.py
+++ b/scripts/yolo_trainer.py
@@ -29,15 +29,17 @@ class YOLOTrainer:
         Configura CometML con las credenciales proporcionadas
         """
         if not self.comet_api_key:
-            self.comet_api_key = input("Ingresa tu API key de CometML: ").strip()
+            self.comet_api_key = os.environ.get("COMET_API_KEY")
             if not self.comet_api_key:
-                print("Error: Se requiere una API key válida de CometML")
+                print("Error: El API KEY de CometML introducido como variable del entorno no es válido.")
+                self.comet_api_key = input("Ingresa tu API key de CometML manualmente: ").strip()
                 return False
                 
         if not self.comet_project:
-            self.comet_project = input("Ingresa el nombre del proyecto en CometML: ").strip()
+            self.comet_project = self.config.get("project", "yolo_project")
             if not self.comet_project:
-                print("Error: Se requiere un nombre de proyecto válido")
+                print("Error: El project de CometML introducido en el config no es válido.")
+                self.comet_project = input("Ingresa el nombre del proyecto en CometML manualmente: ").strip()
                 return False
         
         try:
@@ -76,8 +78,11 @@ class YOLOTrainer:
                 splits.add(split)
                 with open(file_path, "r") as f:
                     for line in f.readlines():
-                        class_id = int(line.split(" ")[0])
-                        classes[id_class_mapping[class_id]][split] += 1
+                        if line.split(" ")[0] != "None":
+                            class_id = int(line.split(" ")[0])
+                            classes[id_class_mapping[class_id]][split] += 1
+                        else:
+                            continue
                         
             splits = list(splits)
             


### PR DESCRIPTION
Changes:

- Allows for the user to manually define the API KEYS once created a virtual environment. This is needed to do only once, since after defining API KEYS as environment variables all the scripts will directly access them using python code.
- Adds the log_instance fucntion to the yolo trainer script, which now allows to log all the instances that were used for a specific training process in both train and validation sets. The information is futher accesible in "Assets" tab in cometml experiment view.
- Handles the issues when the API_KEY was defined as an env_var but still wasn´t accesible by the script, fixing the definition logic.
- Added a new variable inside the yolo_config.yaml so log_instances would work correctly.